### PR TITLE
Fix tooltip bug

### DIFF
--- a/src/FAB.vue
+++ b/src/FAB.vue
@@ -74,7 +74,7 @@
 <script>
     import {mixin as clickaway} from 'vue-clickaway';
     import Ripple from 'vue-ripple-directive';
-    import VTooltip from 'v-tooltip'
+    import {VTooltip} from 'v-tooltip'
 
     export default {
         mixins: [clickaway],


### PR DESCRIPTION
The tooltips don't show, but these changes fix this bug. 

You can test this change by putting 
`"@thijsvdanker/vue-fab": "https://github.com/philipboeken/vue-fab.git#patch-1",`
in the package.json of your preferred project *cough* extranet *cough*