### PR TITLE
Hide invisible padding overlay when FAB is closed

### DIFF
--- a/src/FAB.vue
+++ b/src/FAB.vue
@@ -431,7 +431,7 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        padding-bottom: 20px;
+        padding-bottom: 20px !important;
     }
 
     .fab-list li {

--- a/src/FAB.vue
+++ b/src/FAB.vue
@@ -190,8 +190,7 @@
                     }
                 }
                 return {
-                    bottom: '-20px',
-                    paddingBottom: '20px'
+                    bottom: '-20px'
                 }
             },
             transitionEnter() {
@@ -432,6 +431,7 @@
         display: flex;
         flex-direction: column;
         align-items: center;
+        padding-bottom: 20px;
     }
 
     .fab-list li {


### PR DESCRIPTION
When the FAB is closed, there is a piece of padding (which is there to create some space between the main button and the lowest item when the FAB is opened) causing the height of the closed FAB to be larger than necessary:

![image](https://user-images.githubusercontent.com/32740847/84434432-52749080-ac30-11ea-848e-daeb7a5ae3f5.png)

which causes other elements with lower z-indices to be unclickable.

If we move this 20px padding from the persisting wrapper element to the FAB list which is only displayed when the FAB is opened, this problem is resolved, and we maintain the space between the FAB and the list:

![image](https://user-images.githubusercontent.com/32740847/84434835-07a74880-ac31-11ea-9051-273e631e5110.png)




